### PR TITLE
TAK-13/Auth_Dependency

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -77,4 +77,4 @@ class Permissions():
   
 
 settings = Settings()
-Permission = Permissions(permissions=['assessments::view', 'assessment::take', 'results::view', 'assessments::start'])
+Permission = Permissions(permissions=["assessment.create", "assessment.read", "assessment.update.own", "assessment.update.all", "assessment.delete.own", "assessment.delete.all"])

--- a/app/response_schemas.py
+++ b/app/response_schemas.py
@@ -4,7 +4,7 @@ from app.schemas import STATUS, AssessmentAnswers
 
 
 class AuthenticateUser(BaseModel):
-    user_id: str
+    id: str
     is_super_admin: bool
     permissions: list
 

--- a/app/router.py
+++ b/app/router.py
@@ -159,7 +159,7 @@ async def get_all_user_assessments(user_id:str, db:Session = Depends(get_db), us
 
 
 @router.post("/start-assessment",response_model=StartAssessmentResponse)
-async def start_assessment(request:StartAssessment,db:Session = Depends(get_db),user=Depends(authenticate_user)):
+async def start_assessment(request:StartAssessment,db:Session = Depends(get_db), user:AuthenticateUser=Depends(authenticate_user)):
     '''
     Start an assessment for a user.
 
@@ -276,13 +276,12 @@ async def start_assessment(request:StartAssessment,db:Session = Depends(get_db),
         }
 
     '''
-    if not Permission.check_permission(user.permissions, "assessments::start"):
+    if not Permission.check_permission(user.permissions, "assessment.update.own"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to start assessments")
     
-    user_id = request.user_id
     assessment_id = request.assessment_id
-    _,err = check_for_assessment(user_id=user_id,assessment_id=assessment_id,db=db)
+    _,err = check_for_assessment(user_id=user.id,assessment_id=assessment_id,db=db)
     
     #check for corresponding matching id
     if err:
@@ -322,8 +321,8 @@ async def start_assessment(request:StartAssessment,db:Session = Depends(get_db),
 async def get_assessment_result(
     assessment_id: int,
     user_id: str,
-    db: Session = Depends(get_db),
-    user=Depends(authenticate_user)
+    db: Session = Depends(get_db), 
+    user:AuthenticateUser=Depends(authenticate_user)
 ):
     """
     Retrieve assessment results for a user.
@@ -370,7 +369,7 @@ async def get_assessment_result(
 
 
     """
-    if not Permission.check_permission(user.permissions, "results::view"):
+    if not Permission.check_permission(user.permissions, "assessment.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to view results")
     
@@ -385,35 +384,9 @@ async def get_assessment_result(
 
     return response
 
-# @router.get("/user", response_model=List[UserAssessmentResponse])
-# async def get_all_user_assessments(request:UserAssessmentQuery,db:Session = Depends(get_db), user=Depends(authenticate_user)):
-#     """
-#     Retrieve all assessments taken by a user.
-
-#     Args:
-#         db (Session): SQLAlchemy database session.
-#         user_id (str): ID of the user whose assessments need to be retrieved.
-
-#     Returns:
-#         List[UserAssessment]: List of UserAssessment objects representing the assessments taken by the user.
-#     """
-
-#     if not Permission.check_permission(user.permissions, "assessments::view"):
-#         raise HTTPException(
-#             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to view assessments")
-    
-#     user_id = request.user_id
-    
-#      # Assuming you have a function to fetch a list of user assessments by user_id.
-#     user_assessments = get_user_assessments_from_db(user_id=user_id, db=db)
-#     if not user_assessments:
-#         raise HTTPException(
-#             status_code=status.HTTP_404_NOT_FOUND, detail="User has no assessments")
-
-#     return user_assessments
 
 @router.post("/save_session/")
-def save_endpoint(data: SessionData, user_id: int, user=Depends(authenticate_user)):
+def save_endpoint(data: SessionData, user_id: int, user:AuthenticateUser=Depends(authenticate_user)):
     """
     Saves the session data for a user.
 
@@ -449,7 +422,7 @@ def save_endpoint(data: SessionData, user_id: int, user=Depends(authenticate_use
                 }
     """
 
-    if not Permission.check_permission(user.permissions, "assessment::take"):
+    if not Permission.check_permission(user.permissions, "assessment.update.own" ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to save session")
     # check if user is eligible to submit assessment at first if required
@@ -457,7 +430,7 @@ def save_endpoint(data: SessionData, user_id: int, user=Depends(authenticate_use
     return save_session(data, user_id)
 
 @router.get("/get_all_session/{user_id}")
-def get_all_endpoint(user_id: int, user=Depends(authenticate_user)):
+def get_all_endpoint(user_id: int, user:AuthenticateUser=Depends(authenticate_user)):
 
     """
     Retrieves all sessions for a user.
@@ -543,13 +516,13 @@ def get_all_endpoint(user_id: int, user=Depends(authenticate_user)):
                     }    
     """
 
-    if not Permission.check_permission(user.permissions, "assessment::take"):
+    if not Permission.check_permission(user.permissions, "assessment.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to get all sessions")
     return get_all_session(user_id)
 
 @router.get("/get_session_detail/{user_id}/{assessment_id}")
-def get_detail_endpoint(user_id: int, assessment_id: int, user=Depends(authenticate_user)):
+def get_detail_endpoint(user_id: int, assessment_id: int, user:AuthenticateUser=Depends(authenticate_user)):
     """
     Retrieves session details for a user.
 
@@ -640,7 +613,7 @@ def get_detail_endpoint(user_id: int, assessment_id: int, user=Depends(authentic
                     }
     """
 
-    if not Permission.check_permission(user.permissions, "assessment::take"):
+    if not Permission.check_permission(user.permissions, "assessment.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to get session detail")
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue #26 
[Linear ticket](https://linear.app/zuri-project-backend/issue/TAK-13/auth-dependency#comment-3e613f49)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Initial implementation was not going through the authentication service because it was not available at the time of implementation.

## How Has This Been Tested?
This fix was tested by running changes through the function which then makes a request to authentication service and returns the permission of the user as well as the user id. It was then used by the logic of the service requested
Attached below is the success response showing that it was successful during test
![image](https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/assets/50580088/9b4aa059-496a-4ce4-a2b0-6803b1bb4ce4)


## Screenshots (if appropriate - Postman, etc):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.