### PR TITLE
fixes start assessment

### DIFF
--- a/app/services/external.py
+++ b/app/services/external.py
@@ -68,15 +68,11 @@ def fake_authenticate_user(fake_token: str ="l3h5.34jb3,4mh346gv,34h63vk3j4h5k43
 
     return AuthenticateUser(**data)
     
-#this services method is deprecated; we're using only assessment_id to fetch questions
-def check_for_assessment(user_id:str,assessment_id:str,db:Session):
+def check_for_assessment(assessment_id:str,db:Session):
     """
         Check for assessment:
-            This function checks if the user_id and assessment_id are present in the database
-
+            This function checks for assessment duration_minutes
         Parameters:
-        - user_id : str
-            user id of the user
         - assessment_id : str
             assessment id of the assessment
         - db : Session
@@ -84,17 +80,16 @@ def check_for_assessment(user_id:str,assessment_id:str,db:Session):
 
 
         Returns:
-        - check : UserAssessment
-            returns the UserAssessment object if there is a match
+        - check : Assessment
+            returns the Assessment object if there is a match
         - None : None
             returns None if there is no match
 
     """
-    #validate if the assessment_id and user_id corresponds
-    check = db.query(UserAssessment).filter(UserAssessment.user_id==user_id,UserAssessment.assessment_id==assessment_id).first()
-
+    #validate if the assessment_id  corresponds
+    check = db.query(Assessment).filter(Assessment.id==assessment_id).first()
     if not check :
-        return None,HTTPException(status_code=status.HTTP_404_NOT_FOUND,detail="No assessment found for provided user_id and assessment_id ")
+        return None,HTTPException(status_code=status.HTTP_404_NOT_FOUND,detail="No assessment found for provided assessment_id ")
     
     return check,None
     
@@ -119,9 +114,6 @@ def fetch_questions(assessment_id:str,db:Session):
             returns the list of questions under the assessment_id
     """
     # #query for any questions corresponding to the assessment_id and do a join with the answers table
-    # question_and_answers = db.query(Assessment).filter(Assessment.id==assessment_id).first()
-    
-
     questions = db.query(Question).filter(Question.assessment_id==assessment_id).all()
     if not questions:
         #for any reason if  there are no questions return false

--- a/script.py
+++ b/script.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 questions_and_answer_list = [
   {
+    "question_no":1,
     "question_text": "Test Question 1",
     "question_type": "MCQ",
     "options": [
@@ -17,6 +18,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 1"
     },
   {
+    "question_no":2,
     "question_text": "Test Question 2",
     "question_type": "MCQ",
     "options": [
@@ -28,6 +30,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 2"
     },
   {
+    "question_no":3,
     "question_text": "Test Question 3",
     "question_type": "MCQ",
     "options": [
@@ -39,6 +42,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 3"
     },
   {
+    "question_no":4,
     "question_text": "Test Question 4",
     "question_type": "MCQ",
     "options": [
@@ -50,6 +54,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 4"
     },
   {
+    "question_no":5,
     "question_text": "Test Question 5",
     "question_type": "MCQ",
     "options": [
@@ -61,6 +66,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 1"
     },
   {
+    "question_no":6,
     "question_text": "Test Question 6",
     "question_type": "MCQ",
     "options": [
@@ -72,6 +78,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 2"
     },
   {
+    "question_no":7,
     "question_text": "Test Question 7",
     "question_type": "MCQ",
     "options": [
@@ -83,6 +90,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 3"
     },
   {
+    "question_no":8,
     "question_text": "Test Question 8",
     "question_type": "MCQ",
     "options": [
@@ -94,6 +102,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 4"
     },
   {
+    "question_no":9,
     "question_text": "Test Question 9",
     "question_type": "MCQ",
     "options": [
@@ -105,6 +114,7 @@ questions_and_answer_list = [
     "correct_answer": "Test Option 1"
     },
   {
+    "question_no":10,
     "question_text": "Test Question 10",
     "question_type": "MCQ",
     "options": [
@@ -122,7 +132,7 @@ def run():
 
     # create an assessment 
     assessment = Assessment(
-      skill_id=6, 
+      skill_id=9, 
       title = "Test Assessment",
       description = "Test Assessment Description",
       start_date = datetime.now(),
@@ -140,6 +150,7 @@ def run():
     for question_and_answer in questions_and_answer_list:
       question = Question(
         assessment_id=assessment.id,
+        question_no = question_and_answer["question_no"],
         question_text=question_and_answer["question_text"],
         question_type=question_and_answer["question_type"]
         
@@ -157,6 +168,9 @@ def run():
       db.add(answer)
       db.commit()
       db.refresh(answer)
+
+    print("Done writing in database")
+    print(f"assessment_id: {assessment.id}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
I fixed the start assessment endpoint to properly return the questions and answers' options. I also added the cookie values as directed by the team lead @blacdev .

## Related Issue (Link to linear ticket)
Issue number: #8
Link to linear ticket: https://linear.app/zuri-project-backend/issue/TAK-3/start-assessment

## Motivation and Context
The response was returning only questions (id, text, type ); but the client should also receive answers' options for MCQ. Also the assessment session endpoint was up running so there was need to set the cookie values to be used to monitor the session.

## How Has This Been Tested?
The code was tested locally with connection to remote database; everything worked well on localhost.

## Screenshots
![pr1](https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/assets/111475184/78f4ad93-2be2-4b8c-b439-391a3166d8ae)

![pr2](https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/assets/111475184/bd828c62-636b-4910-a919-7d7bc52432bc)

![pr3](https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/assets/111475184/b98efa19-9ffa-48d1-b476-5651823d9aa3)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.