### PR TITLE
added endpoint for listing all user completed assessments

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -133,7 +133,7 @@ class UserAssessment(BaseModel):
     assessment = relationship("Assessment", back_populates="user_assessment", lazy="joined")
     user_response = relationship(
         "UserResponse", back_populates="user_assessment", lazy="joined")
-    user_badge = relationship("UserBadge", back_populates="assessment", lazy="joined")
+    user_badge = relationship("UserBadge", back_populates="user_assessment", lazy="joined")
 
 
 class Assessment(BaseModel):
@@ -340,7 +340,7 @@ class SkillBadge(DATEBaseModel):
     )
 
     skill = relationship("Skill", back_populates="skill_badge")
-    user_badge = relationship("UserBadge", back_populates="badge")
+    user_badge = relationship("UserBadge", back_populates="skill_badge",lazy="joined")
 
 
 class UserResponse(BaseModel):
@@ -454,8 +454,8 @@ class UserBadge(DATEBaseModel):
                        nullable=False, onupdate=text("now()"))
 
     user = relationship("User", back_populates="user_badge")
-    badge = relationship("SkillBadge", back_populates="user_badge")
-    assessment = relationship("UserAssessment", back_populates="user_badge")
+    skill_badge = relationship("SkillBadge", back_populates="user_badge",lazy="joined")
+    user_assessment = relationship("UserAssessment", back_populates="user_badge",lazy="joined")
 
 
 class Track(BaseModel):
@@ -467,4 +467,3 @@ class UserTrack(BaseModel):
     user_id = Column(UUID, ForeignKey(
     "user.id", ondelete="CASCADE"), nullable=False)
     track_id = Column(Integer)
-    

--- a/app/router.py
+++ b/app/router.py
@@ -9,7 +9,7 @@ from app.services.external import (
         fetch_answered_and_unanswered_questions
     )
 from app.services.user_assessment import get_user_assessments_from_db
-from app.services.assessment import get_assessment_results
+from app.services.assessment import get_assessment_results,get_completed_assessments
 from app.schemas import StartAssessment, UserAssessmentQuery, UserAssessmentanswer
 from app.response_schemas import StartAssessmentResponse, UserAssessmentResponse, Questions,SingleAssessmentResponse
 from app.services.user_session import  save_session,send_email
@@ -153,7 +153,7 @@ async def get_all_user_assessments(token:str = Header(...), db: Session = Depend
     status_code: 500
     }
     """
-    
+
     user = authenticate_user(token=token, permission="assessment.read")
     # user = fake_authenticate_user()
 
@@ -322,7 +322,7 @@ async def start_assessment( request:StartAssessment,response:Response, token:str
     #check for corresponding matching id
     if err:
         raise err
-    
+
     if not assessment_instance:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,detail="Critical error occured while getting assessment details")
 
@@ -339,7 +339,7 @@ async def start_assessment( request:StartAssessment,response:Response, token:str
     #check for availability of questions under the assessment_id
     if error:
         raise error
-    
+
     if not questions_instance:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,detail="Critical error occured while fetching questions")
 
@@ -371,7 +371,7 @@ async def start_assessment( request:StartAssessment,response:Response, token:str
         db.commit()
         db.refresh(user_assessment)
 
-    
+
     return {
         "message": "Assessment started successfully",
         "status_code": 200,
@@ -405,7 +405,7 @@ async def get_session_details(response:Request,token:str = Header(...),db:Sessio
 
     if error:
         raise error
-    
+
     if not unanswered_question:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,detail="Assessment already completed")
 
@@ -423,7 +423,7 @@ async def get_session_details(response:Request,token:str = Header(...),db:Sessio
                 options=question.answer.options,
                 user_selected_answer= question.selected_response,
                 ))
-            
+
     if unanswered_question != []:
 
         for question in unanswered_question:
@@ -448,8 +448,8 @@ async def get_session_details(response:Request,token:str = Header(...),db:Sessio
 async def get_assessment_result(
     assessment_id: int,
     token:str = Header(...),
-    db: Session = Depends(get_db), 
-   
+    db: Session = Depends(get_db),
+
 ):
     """
     Retrieve assessment results for a user.
@@ -551,17 +551,29 @@ async def submit_assessment(
 
     # check if user is eligible to submit assessment at first if required
     # user_id comes from auth
-    
+
     return save_session(response, user.id,db=db, background_task=background_task)
+
+
+
+@router.get('/get-user-assessments')
+def get_user_completed_assessments(token:str = Header(...),db:Session = Depends(get_db)):
+    user = authenticate_user(token=token, permission="assessment.read")
+    # user=fake_authenticate_user()
+    completed_assessments,error=get_completed_assessments(user.id,db=db)
+    if error:
+        raise error
+    return completed_assessments
+
 
 
 
 
 @router.get("/{skill_id}")
 def get_assessment(skill_id:int, token:str = Header(...),db:Session = Depends(get_db),):
-    
+
     user = authenticate_user(token=token, permission="assessment.read")
-    #edit below to match the right permission 
+    #edit below to match the right permission
     if not Permission.check_permission(user.permissions, "assessment.read"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail="User does not have permission to start assessments")
@@ -573,15 +585,15 @@ def get_assessment(skill_id:int, token:str = Header(...),db:Session = Depends(ge
         raise error
     if not single_assessment_instance:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,detail="Critical error occured while getting assessment details")
-    
+
     question_count, err = fetch_questions(assessment_id=single_assessment_instance.id,db=db, count=True)
 
     if err:
         raise err
-    
+
     if not question_count:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,detail="Critical error occured while getting assessment details")
-    
+
     response = {
         "assessment_id":single_assessment_instance.id,
         "skill_id": skill_id,
@@ -595,3 +607,5 @@ def get_assessment(skill_id:int, token:str = Header(...),db:Session = Depends(ge
         }
 
     return response
+
+

--- a/app/services/assessment.py
+++ b/app/services/assessment.py
@@ -29,7 +29,7 @@ def get_assessment_results(user_id: str, assessment_id: int, db : Session):
         status of the assessment
     - db_questions : List[Question]
         list of questions in the assessment
-        
+
     """
 
     valid_user = db.query(User).filter(User.id == user_id).first()
@@ -39,12 +39,12 @@ def get_assessment_results(user_id: str, assessment_id: int, db : Session):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"User with id {user_id} not found",
         )
-    
+
     query = db.query(UserAssessment)\
         .filter(
             and_(UserAssessment.user_id==user_id, UserAssessment.assessment_id==assessment_id)\
             )
-    
+
     assessment = query.first()
 
     if not assessment:
@@ -52,14 +52,14 @@ def get_assessment_results(user_id: str, assessment_id: int, db : Session):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Assessment with id {assessment_id} not found",
         )
-    
+
     score = assessment.score
     assessment_status = assessment.status
 
     db_questions = db.query(Question).join(Answer, Question.id == Answer.question_id)\
                     .filter(Question.assessment_id == assessment_id).all()
-    
-    
+
+
     questions_with_answers = []
     for item in db_questions:
         var = {}
@@ -68,7 +68,7 @@ def get_assessment_results(user_id: str, assessment_id: int, db : Session):
 
         answer = question['answer'].__dict__
         var['answer_text'] = answer['correct_option']
-        
+
         questions_with_answers.append(var)
 
 
@@ -80,21 +80,21 @@ def get_assessment_results(user_id: str, assessment_id: int, db : Session):
     # assessment_obj = None
 
     # for assessment in UserAssessments:
-     
+
     #     if assessment['assessment_id'] == assessment_id:
     #         assessment_obj = assessment
     #     else:
     #         continue
-    
+
 
     # if assessment_obj is None:
     #     raise HTTPException(
     #         status_code=status.HTTP_404_NOT_FOUND,
     #         detail=f"Assessment with id {assessment_id} not found",
     #     )
-    
+
     # score = assessment_obj.get('score')
-    # assessment_status = assessment_obj.get('status')   
+    # assessment_status = assessment_obj.get('status')
 
     # db_questions = [question for question in Questions if question['assessment_id'] == assessment_id]
     # for question in db_questions:
@@ -106,3 +106,29 @@ def get_assessment_results(user_id: str, assessment_id: int, db : Session):
     #             continue
 
     return score, assessment_status, questions_with_answers
+
+def get_completed_assessments(user_id,db:Session):
+    completed_assessments=db.query(UserAssessment).filter(UserAssessment.user_id==user_id,UserAssessment.status=='complete').all()
+    if completed_assessments==[]:
+        return None,HTTPException(status_code=404,detail="no assessment found")
+
+    response=[]
+    for assessment in completed_assessments:
+        response.append(
+            {
+                "assessment_id":assessment.assessment_id,
+                "score":assessment.score,
+                "id": assessment.id,
+                "user_id": assessment.user_id,
+                "status": assessment.status,
+                "submission_date": assessment.submission_date,
+                "badge_id":assessment.user_badge[0].badge_id,
+                "badge_name":assessment.user_badge[0].skill_badge.name,
+                "skill_id":assessment.user_badge[0].skill_badge.skill_id
+
+
+            }
+        )
+    return response,None
+
+

--- a/app/services/external.py
+++ b/app/services/external.py
@@ -20,7 +20,7 @@ def authenticate_user(permission: str,token: str ):
 
     Raises:
     - HTTPException: This is raised if the authentication service returns a status code other than 200.
-    
+
     """
 
     request = post(
@@ -32,10 +32,10 @@ def authenticate_user(permission: str,token: str ):
 
     if request.get("status") == 401:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    
+
     if request.get("status") != 200:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
-    
+
     if Permission.check_permission(request.get("user").get("permissions"), permission):
 
         data = {
@@ -61,18 +61,18 @@ def fake_authenticate_user(fake_token: str ="l3h5.34jb3,4mh346gv,34h63vk3j4h5k43
 
     Raises:
     - HTTPException: This is raised if the authentication service returns a status code other than 200.
-    
+
     """
     if fake_token != "l3h5.34jb3,4mh346gv,34h63vk3j4h5k43hjg54kjhkg4j6h45g6kjh45gk6jh6k6g34hj6":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
-    
+
     data = {
         "id": "e2009b92-8acf-406d-a974-95fb6a5215f3",
         "permissions": ["assessment.create", "assessment.read", "assessment.update.own", "assessment.update.all", "assessment.delete.own", "assessment.delete.all"]
     }
 
     return AuthenticateUser(**data)
-    
+
 def check_for_assessment(assessment_id:str,db:Session):
     """
         Check for assessment:
@@ -95,9 +95,9 @@ def check_for_assessment(assessment_id:str,db:Session):
     check = db.query(Assessment).filter(Assessment.id==assessment_id).first()
     if not check :
         return None,HTTPException(status_code=status.HTTP_404_NOT_FOUND,detail="No assessment found for provided assessment_id ")
-    
+
     return check,None
-    
+
 
 
 
@@ -123,7 +123,7 @@ def fetch_questions(assessment_id:str, count:bool,db:Session):
 
     if count:
         return questions.count(), None
-    
+
     questions = questions.all()
 
     if not questions:
@@ -131,7 +131,7 @@ def fetch_questions(assessment_id:str, count:bool,db:Session):
         err_message = "No questions found under the assessment_id"
         return None, HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_message)
     return questions, None
-    
+
 
 
 def fetch_single_assessment(skill_id:str,db:Session):
@@ -158,7 +158,7 @@ def fetch_single_assessment(skill_id:str,db:Session):
 
     if not assessment_details :
         return None,HTTPException(status_code=status.HTTP_404_NOT_FOUND,detail="No assessment found")
-    
+
     return assessment_details,None
 
 def fetch_answered_and_unanswered_questions(assessment_id:str, user_id:str,db:Session):
@@ -180,10 +180,10 @@ def fetch_answered_and_unanswered_questions(assessment_id:str, user_id:str,db:Se
 
         - questions : list
             returns the list of unanswered questions under the assessment_id
-        
+
         - None : None
             returns None if there is no match
-        
+
         - HTTPException : HTTPException
             returns HTTPException if there is no match
     """
@@ -193,14 +193,14 @@ def fetch_answered_and_unanswered_questions(assessment_id:str, user_id:str,db:Se
         #for any reason if  there are no questions return false
         err_message = "No questions found under the assessment_id"
         return None, None,HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_message)
-    
+
     #query for any questions corresponding to the assessment_id
     user_assement_instance = db.query(UserAssessment).filter(UserAssessment.assessment_id==assessment_id, UserAssessment.user_id==user_id).first()
     if not user_assement_instance:
         #for any reason if  there are no questions return false
         err_message = "No questions found under the assessment_id"
         return None, None,HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_message)
-    
+
     answered_questions = db.query(UserResponse).filter(UserResponse.user_assessment_id==user_assement_instance.id).all()
 
     if answered_questions != []:
@@ -210,4 +210,3 @@ def fetch_answered_and_unanswered_questions(assessment_id:str, user_id:str,db:Se
                     questions.remove(question)
 
     return questions, answered_questions, None
-        

--- a/app/services/user_session.py
+++ b/app/services/user_session.py
@@ -96,7 +96,7 @@ def save_session(data: UserAssessmentanswer, user_id: int, db:Session, backgroun
             db.refresh(user_assessment_instance)
 
             # assign badge
-            assign_badge(user_id, user_assessment_instance.assessment_id)
+            assign_badge(user_id, user_assessment_instance.id)
             background_task.add_task(send_email, user_id, db)
             '''
             # check if each badge where the score falls within the range
@@ -148,5 +148,4 @@ def assign_badge(user_id, assessment_id):
         f"{settings.BADGE_SERVICE}",
         headers={},
         data={"user_id": user_id, "assessment_id":assessment_id}).json()
-    
-    
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This endpoint returns the completed assessment of a user
## Description
This endpoint returns a list of completed assessment of an authenticated user, with the respective badges

## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://linear.app/zuri-project-backend/issue/TAK-10/list-all-assessment-taken

https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/issues/44

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To assist the frontend application to easily fetch completed assessments and allocate the respective badges to those assessments

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
the code was tested, debugged and fixed to meet the requirements, the testing was done with the documentation api

## Screenshots (if appropriate - Postman, etc):
![Screenshot (525)](https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/assets/101363689/72b411cb-ac08-4fcb-ae73-9486233e22b2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ]ew feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
