### PR TITLE
Fix issue with start assesment and get session

### DIFF
--- a/app/response_schemas.py
+++ b/app/response_schemas.py
@@ -19,6 +19,7 @@ class Questions(BaseModel):
     question_no: int
     question_text: str
     question_type: str
+    answer_id: int
     user_selected_answer: Optional[str] = None
     options: Set
 class StartAssessmentResponse(Questions):

--- a/app/services/external.py
+++ b/app/services/external.py
@@ -188,18 +188,20 @@ def fetch_answered_and_unanswered_questions(assessment_id:str, user_id:str,db:Se
             returns HTTPException if there is no match
     """
     #query for any questions corresponding to the assessment_id
+    user_assement_instance = db.query(UserAssessment).filter(UserAssessment.assessment_id==assessment_id, UserAssessment.user_id==user_id, UserAssessment.status == "pending").first()
+    if not user_assement_instance:
+        #for any reason if  there are no questions return false
+        err_message = "No questions found under the assessment_id"
+        return None, None,HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_message)
+    
+
+    #query for any questions corresponding to the assessment_id
     questions = db.query(Question).filter(Question.assessment_id==assessment_id).all()
     if not questions:
         #for any reason if  there are no questions return false
         err_message = "No questions found under the assessment_id"
         return None, None,HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_message)
 
-    #query for any questions corresponding to the assessment_id
-    user_assement_instance = db.query(UserAssessment).filter(UserAssessment.assessment_id==assessment_id, UserAssessment.user_id==user_id).first()
-    if not user_assement_instance:
-        #for any reason if  there are no questions return false
-        err_message = "No questions found under the assessment_id"
-        return None, None,HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_message)
 
     answered_questions = db.query(UserResponse).filter(UserResponse.user_assessment_id==user_assement_instance.id).all()
 

--- a/app/services/user_session.py
+++ b/app/services/user_session.py
@@ -27,7 +27,7 @@ def save_session(data: UserAssessmentanswer, user_id: int, db:Session, backgroun
         status code of the response
 
     """
-    user_assessment_instance = db.query(UserAssessment).filter(UserAssessment.user_id==user_id,UserAssessment.assessment_id==data.assessment_id).first()
+    user_assessment_instance = db.query(UserAssessment).filter(UserAssessment.user_id==user_id,UserAssessment.assessment_id==data.assessment_id, UserAssessment.status == "pending").first()
 
     if not user_assessment_instance:
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND,detail="There is no match for user_id or assessment_id")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix  start assessment and get session endpoint

## Description
<!--- Describe your changes in detail -->
This change removes initial flow of setting a cookie to determine if the user session is still active. The new flow takes in the assessment id and checks if the user has that assessment as pending.

## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Link to issue - #50 
[Link to related linear issue](https://linear.app/zuri-project-backend/issue/TAK-3/start-assessment)
[Link to related linear issue](https://linear.app/zuri-project-backend/issue/TAK-8/get-user-assessment-session)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It became a bug that was hindering advancement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested by starting and retrieving an assessment

## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/hngx-org/Team-Empire-Portfolio-User-Taking-Assesments/assets/50580088/9348f6c8-fc73-4f5f-8a87-7a8a9f93a413)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
